### PR TITLE
Using bit shifting in LCD_Cmd4bit() func

### DIFF
--- a/LCD.c
+++ b/LCD.c
@@ -246,10 +246,11 @@ static void LCD_Data(uint8_t data)
 //############################################################################################
 static void LCD_Cmd4bit(uint8_t cmd)
 {
-	HAL_GPIO_WritePin(_LCD_D7_PORT, _LCD_D7_PIN, (GPIO_PinState)(cmd & 0x08));
-	HAL_GPIO_WritePin(_LCD_D6_PORT, _LCD_D6_PIN, (GPIO_PinState)(cmd & 0x04));
-	HAL_GPIO_WritePin(_LCD_D5_PORT, _LCD_D5_PIN, (GPIO_PinState)(cmd & 0x02));
+	HAL_GPIO_WritePin(_LCD_D7_PORT, _LCD_D7_PIN, (GPIO_PinState)((cmd & 0x08) >> 3));
+	HAL_GPIO_WritePin(_LCD_D6_PORT, _LCD_D6_PIN, (GPIO_PinState)((cmd & 0x04) >> 2));
+	HAL_GPIO_WritePin(_LCD_D5_PORT, _LCD_D5_PIN, (GPIO_PinState)((cmd & 0x02) >> 1));
 	HAL_GPIO_WritePin(_LCD_D4_PORT, _LCD_D4_PIN, (GPIO_PinState)(cmd & 0x01));
+	
 	LCD_E_BLINK;
 }
 //############################################################################################


### PR DESCRIPTION



since you are passing the bit value of cmd as the third passing argument of "HAL_GPIO_WritePin" , only the least significant bit of value is taken by this function.

```cpp
static void LCD_Cmd4bit(uint8_t cmd)
{
HAL_GPIO_WritePin(_LCD_D7_PORT, _LCD_D7_PIN, (GPIO_PinState)(cmd & 0x08));
HAL_GPIO_WritePin(_LCD_D6_PORT, _LCD_D6_PIN, (GPIO_PinState)(cmd & 0x04));
HAL_GPIO_WritePin(_LCD_D5_PORT, _LCD_D5_PIN, (GPIO_PinState)(cmd & 0x02));
HAL_GPIO_WritePin(_LCD_D4_PORT, _LCD_D4_PIN, (GPIO_PinState)(cmd & 0x01));
LCD_E_BLINK;
}
```


in above code only the last bit of cmd is written and three other bits are missing . Therefore they need to be shifted as long as they take the first bit position :

```cpp
{
	HAL_GPIO_WritePin(_LCD_D7_PORT, _LCD_D7_PIN, (GPIO_PinState)((cmd & 0x08) >> 3));
	HAL_GPIO_WritePin(_LCD_D6_PORT, _LCD_D6_PIN, (GPIO_PinState)((cmd & 0x04) >> 2));
	HAL_GPIO_WritePin(_LCD_D5_PORT, _LCD_D5_PIN, (GPIO_PinState)((cmd & 0x02) >> 1));
	HAL_GPIO_WritePin(_LCD_D4_PORT, _LCD_D4_PIN, (GPIO_PinState)(cmd & 0x01));
	LCD_E_BLINK;
}
```

